### PR TITLE
Simplify regex to support paths wrapped with quotes

### DIFF
--- a/src/pass-sshaskpass.sh
+++ b/src/pass-sshaskpass.sh
@@ -4,7 +4,7 @@
 # Contributor  Frederik Schwan <frederik dot schwan at linux dot com>
 # This file is licensed under the GPLv2+. Please see LICENSE for more information.
 
-key=$(echo "$1" | sed -r "s/.*\/(.*)(':|:\s*$)/\1/g")
+key=$(echo "$1" | sed -r "s/.*\/([^':]+)'?:\s*$/\1/g")
 
 mypass=$(pass ssh/$key)
 

--- a/src/pass-sshaskpass.sh
+++ b/src/pass-sshaskpass.sh
@@ -9,7 +9,7 @@ key=$(echo "$1" | sed -r "s/.*\/([^':]+)'?:\s*$/\1/g")
 mypass=$(pass ssh/$key)
 
 if [[ $? != 0 ]] ; then
-	zenity --error --text="Passphrase not found in password store. Please store it with 'pass insert ssh/$key'"
+    zenity --error --text="Passphrase not found in password store. Please store it with 'pass insert ssh/$key'"
 else
     echo "$mypass"
 fi


### PR DESCRIPTION
The previous regex didn't support the message "Enter passphrase for key '/home/slang/.ssh/id_rsa':" which I got from [Smartgit](http://syntevo.com/smartgit/) running on Arch. It would end up setting `$key` as `id_rsa'` (including the trailing single quote).

This change assumes that there are no quotes in the path to the key, but supports a more general structure for messages in `$1`.

The current regex looks like this:

![1453736362](https://cloud.githubusercontent.com/assets/1049204/12556022/ec25c63a-c351-11e5-97e9-731d2f8fa32e.png)

And the proposed is:

![1453736398](https://cloud.githubusercontent.com/assets/1049204/12556032/f512e8fe-c351-11e5-8757-e3a774b88e11.png)
